### PR TITLE
rs-tarpaulin codecov

### DIFF
--- a/.github/workflows/tarpaulin.yml
+++ b/.github/workflows/tarpaulin.yml
@@ -1,0 +1,37 @@
+---
+name: tarpaulin
+"on": 
+  push:
+  pull_request:
+
+
+jobs:
+  check:
+    name: Rust project
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: '0.15.0'
+          args: '-- --test-threads 1'
+
+#       - name: Upload to codecov.io
+#         uses: codecov/codecov-action@v1.0.2
+#         with:
+#           token: ${{secrets.CODECOV_TOKEN}}
+
+#       - name: Archive code coverage results
+#         uses: actions/upload-artifact@v1
+#         with:
+#           name: code-coverage-report
+#           path: cobertura.xml


### PR DESCRIPTION
Workflow for the test coverage  added. 
Source : https://github.com/actions-rs/tarpaulin
TBA: uploading coverage reports to Codecov
``` tarpaulin.yml
      - name: Upload to codecov.io
        uses: codecov/codecov-action@v1.0.2
        with:
          token: *CODECOV_TOKEN*

      - name: Archive code coverage results
        uses: actions/upload-artifact@v1
        with:
          name: code-coverage-report
          path: cobertura.xml
```