### PR TITLE
fix(reo): validate --root as u32 to avoid panic on non-numeric input

### DIFF
--- a/src/bin/reo.rs
+++ b/src/bin/reo.rs
@@ -147,6 +147,7 @@ pub fn main() -> Result<()> {
                         .required(false)
                         .default_value("0")
                         .help("The ID of the root vertex")
+                        .value_parser(value_parser!(u32))
                         .action(ArgAction::Set),
                 )
                 .arg(
@@ -201,6 +202,7 @@ pub fn main() -> Result<()> {
                         .required(false)
                         .default_value("0")
                         .help("The ID of the root vertex to print")
+                        .value_parser(value_parser!(u32))
                         .action(ArgAction::Set),
                 )
                 .arg(
@@ -367,7 +369,7 @@ pub fn main() -> Result<()> {
                 fs::metadata(bin)?.len(),
                 start.elapsed()
             );
-            let root: u32 = subs.get_one::<String>("root").unwrap().parse().unwrap();
+            let root: u32 = *subs.get_one::<u32>("root").unwrap();
             let ignore: HashSet<u32> = HashSet::from_iter(
                 subs.get_many("ignore")
                     .unwrap_or(ValuesRef::default())
@@ -401,7 +403,7 @@ pub fn main() -> Result<()> {
             println!("Total vertices: {}", g.len());
             println!("Metas:");
             print_metas(&mut g)?;
-            let root = subs.get_one::<String>("root").unwrap().parse().unwrap();
+            let root = *subs.get_one::<u32>("root").unwrap();
             let mut seen = HashSet::new();
             let ignore: Vec<u32> = subs
                 .get_many("ignore")

--- a/tests/dot_test.rs
+++ b/tests/dot_test.rs
@@ -46,3 +46,22 @@ fn mentions_stdout_fallback_in_help() {
         .success()
         .stdout(predicate::str::contains("prints to stdout when omitted"));
 }
+
+#[test]
+fn rejects_non_numeric_root() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let bin = tmp.path().join("first.reo");
+    let dot = tmp.path().join("first.dot");
+    compile_one("ADD(ν0);", bin.clone())?;
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .current_dir(tmp.path())
+        .arg("dot")
+        .arg("--root=xyz")
+        .arg(bin.as_os_str())
+        .arg(dot.as_os_str())
+        .assert()
+        .failure()
+        .code(2);
+    Ok(())
+}

--- a/tests/inspect_test.rs
+++ b/tests/inspect_test.rs
@@ -34,3 +34,20 @@ fn inspects_one_binary() -> Result<()> {
         .success();
     Ok(())
 }
+
+#[test]
+fn rejects_non_numeric_root() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let first = tmp.path().join("first.reo");
+    compile_one("ADD(ν0);", first.clone())?;
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .current_dir(tmp.path())
+        .arg("inspect")
+        .arg("--root=abc")
+        .arg(first.as_os_str())
+        .assert()
+        .failure()
+        .code(2);
+    Ok(())
+}


### PR DESCRIPTION
The `--root` argument for the `dot` and `inspect` subcommands was declared without a `value_parser`, so a non-numeric value like `--root abc` slipped past clap and only failed later at `.parse().unwrap()`, aborting with a raw Rust panic (`ParseIntError`) instead of a clean CLI error.

This adds `.value_parser(value_parser!(u32))` to both `--root` args, matching the sibling `--ignore` argument, and reads the value as a parsed `u32` at the call sites. Invalid input now produces clap's normal "invalid value" message and exit code 2. Added a regression test to each of `inspect_test` and `dot_test`.

Closes #212.