### PR TITLE
#213: Clarify dot output argument

### DIFF
--- a/src/bin/reo.rs
+++ b/src/bin/reo.rs
@@ -223,9 +223,8 @@ pub fn main() -> Result<()> {
                 )
                 .arg(
                     Arg::new("dot")
-                        .required(true)
                         .value_parser(PathValueParser {})
-                        .help("Name of a .dot file to create")
+                        .help("Name of a .dot file to create; prints to stdout when omitted")
                         .takes_value(true)
                         .required(false)
                         .action(ArgAction::Set),

--- a/tests/dot_test.rs
+++ b/tests/dot_test.rs
@@ -5,6 +5,7 @@ mod common;
 
 use crate::common::compiler::compile_one;
 use anyhow::Result;
+use predicates::prelude::predicate;
 use tempfile::TempDir;
 
 #[test]
@@ -33,4 +34,15 @@ fn prints_dot() -> Result<()> {
         .success();
     assert!(dot.exists());
     Ok(())
+}
+
+#[test]
+fn mentions_stdout_fallback_in_help() {
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .arg("dot")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("prints to stdout when omitted"));
 }


### PR DESCRIPTION
Closes #213.

## Problem

The `dot` subcommand declared its `dot` output argument as both required and optional.

The optional behavior is intentional: when the output file is omitted, `reo dot` prints the graph to stdout. However, the source contained a dead `.required(true)` call, and the help text did not mention the stdout fallback.

## Solution

Removed the contradictory `.required(true)` call from the `dot` argument declaration and updated the help text to document stdout output when the argument is omitted.

Added a regression test for `reo dot --help`.

## Testing

```bash
cargo fmt --check
cargo test
```