### PR TITLE
fix(#212): type --root as u32 in clap

### DIFF
--- a/src/bin/reo.rs
+++ b/src/bin/reo.rs
@@ -146,6 +146,7 @@ pub fn main() -> Result<()> {
                         .short('r')
                         .required(false)
                         .default_value("0")
+                        .value_parser(value_parser!(u32))
                         .help("The ID of the root vertex")
                         .action(ArgAction::Set),
                 )
@@ -200,6 +201,7 @@ pub fn main() -> Result<()> {
                         .short('r')
                         .required(false)
                         .default_value("0")
+                        .value_parser(value_parser!(u32))
                         .help("The ID of the root vertex to print")
                         .action(ArgAction::Set),
                 )
@@ -367,7 +369,9 @@ pub fn main() -> Result<()> {
                 fs::metadata(bin)?.len(),
                 start.elapsed()
             );
-            let root: u32 = subs.get_one::<String>("root").unwrap().parse().unwrap();
+            let root = *subs
+                .get_one::<u32>("root")
+                .context("The root vertex ID is required")?;
             let ignore: HashSet<u32> = HashSet::from_iter(
                 subs.get_many("ignore")
                     .unwrap_or(ValuesRef::default())
@@ -401,7 +405,9 @@ pub fn main() -> Result<()> {
             println!("Total vertices: {}", g.len());
             println!("Metas:");
             print_metas(&mut g)?;
-            let root = subs.get_one::<String>("root").unwrap().parse().unwrap();
+            let root = *subs
+                .get_one::<u32>("root")
+                .context("The root vertex ID is required")?;
             let mut seen = HashSet::new();
             let ignore: Vec<u32> = subs
                 .get_many("ignore")

--- a/tests/dot_test.rs
+++ b/tests/dot_test.rs
@@ -46,3 +46,20 @@ fn mentions_stdout_fallback_in_help() {
         .success()
         .stdout(predicate::str::contains("prints to stdout when omitted"));
 }
+
+#[test]
+fn rejects_non_numeric_root_for_dot() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let bin = tmp.path().join("first.reo");
+    compile_one("ADD(ν0);", bin.clone())?;
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .current_dir(tmp.path())
+        .arg("dot")
+        .arg("--root=oops")
+        .arg(bin.as_os_str())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value 'oops' for '--root <root>'"));
+    Ok(())
+}

--- a/tests/inspect_test.rs
+++ b/tests/inspect_test.rs
@@ -5,6 +5,7 @@ mod common;
 
 use crate::common::compiler::compile_one;
 use anyhow::Result;
+use predicates::prelude::predicate;
 use tempfile::TempDir;
 
 #[test]
@@ -32,5 +33,22 @@ fn inspects_one_binary() -> Result<()> {
         .arg(first.as_os_str())
         .assert()
         .success();
+    Ok(())
+}
+
+#[test]
+fn rejects_non_numeric_root_for_inspect() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let first = tmp.path().join("first.reo");
+    compile_one("ADD(ν0);", first.clone())?;
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .current_dir(tmp.path())
+        .arg("inspect")
+        .arg("--root=oops")
+        .arg(first.as_os_str())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value 'oops' for '--root <root>'"));
     Ok(())
 }


### PR DESCRIPTION
Closes  #212.

## What was happening

`dot` and `inspect` accepted `--root` as a string and then parsed it manually with `parse().unwrap()`. Invalid input could therefore panic inside the command instead of being rejected by argument parsing.

## What changed

- type `--root` as `u32` directly in clap
- remove the manual parsing path
- add regression tests for invalid `--root` values in both `dot` and `inspect`
