### PR TITLE
#240: Propagate DOT output creation errors

### DIFF
--- a/src/bin/reo.rs
+++ b/src/bin/reo.rs
@@ -380,7 +380,7 @@ pub fn main() -> Result<()> {
                 Some(f) => {
                     let path = Path::new(f);
                     info!("Printing to '{}' file...", path.display());
-                    Box::new(File::create(path).unwrap()) as Box<dyn Write>
+                    Box::new(File::create(path)?) as Box<dyn Write>
                 }
                 None => Box::new(io::stdout()) as Box<dyn Write>,
             };

--- a/tests/dot_test.rs
+++ b/tests/dot_test.rs
@@ -5,7 +5,7 @@ mod common;
 
 use crate::common::compiler::compile_one;
 use anyhow::Result;
-use predicates::prelude::predicate;
+use predicates::prelude::{predicate, PredicateBooleanExt};
 use tempfile::TempDir;
 
 #[test]
@@ -45,4 +45,22 @@ fn mentions_stdout_fallback_in_help() {
         .assert()
         .success()
         .stdout(predicate::str::contains("prints to stdout when omitted"));
+}
+
+#[test]
+fn reports_output_creation_error_without_panicking() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let bin = tmp.path().join("input.reo");
+    let dot = tmp.path().join("missing").join("output.dot");
+    compile_one("ADD(ν0);", bin.clone())?;
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .arg("dot")
+        .arg(bin.as_os_str())
+        .arg(dot.as_os_str())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error:"))
+        .stderr(predicate::str::contains("panicked").not());
+    Ok(())
 }


### PR DESCRIPTION
Closes #240.

`reo dot` previously unwrapped `File::create()` for the optional DOT output path. Any ordinary creation failure therefore aborted the process with a Rust panic and exit code 101, while the CLI already returns `anyhow::Result<()>` and can propagate the I/O error normally.

This patch replaces the `unwrap()` with `?` and adds a regression test that uses a valid `.reo` input with an output file under a missing parent directory. The test asserts a normal CLI failure, an `Error:` diagnostic, and specifically that stderr does not contain a panic.

Validation on current master base:

- `cargo test --test dot_test` — passed (5/5)
- `cargo test --all-targets` — passed
- `cargo fmt --check` — passed
- `git diff --check` — passed
