### PR TITLE
#242: Propagate inspect graph errors

### DIFF
--- a/src/bin/reo.rs
+++ b/src/bin/reo.rs
@@ -419,7 +419,7 @@ pub fn main() -> Result<()> {
             }
             println!("\nν{root}");
             seen.insert(root);
-            inspect_v(&mut g, root, 1, &mut seen);
+            inspect_v(&mut g, root, 1, &mut seen)?;
             println!("Vertices just printed: {}", seen.len());
             if seen.len() != g.ids().len() {
                 let mut missed = vec![];
@@ -441,7 +441,7 @@ pub fn main() -> Result<()> {
                     for v in missed.into_iter().take(10) {
                         seen.insert(v);
                         println!("  ν{}", v);
-                        inspect_v(&mut g, v, 2, &mut seen);
+                        inspect_v(&mut g, v, 2, &mut seen)?;
                     }
                 }
             }
@@ -470,23 +470,24 @@ fn print_metas(g: &mut Sodg) -> Result<()> {
     Ok(())
 }
 
-fn inspect_v(g: &mut Sodg, v: u32, indent: usize, seen: &mut HashSet<u32>) {
-    let mut kids = g.kids(v).unwrap();
+fn inspect_v(g: &mut Sodg, v: u32, indent: usize, seen: &mut HashSet<u32>) -> Result<()> {
+    let mut kids = g.kids(v)?;
     kids.sort_by(|a, b| a.0.cmp(&b.0.clone()));
     for e in kids {
         print!("{}", "  ".repeat(indent));
         print!("{} -> ν{}", e.0, e.1);
         if e.0 == "Δ" {
-            print!(" {}", g.data(e.1).unwrap().to_string().blue());
+            print!(" {}", g.data(e.1)?.to_string().blue());
         }
         if e.0 == "λ" {
-            print!(" {}", g.data(e.1).unwrap().to_utf8().unwrap().yellow());
+            print!(" {}", g.data(e.1)?.to_utf8()?.yellow());
         }
         println!();
         if seen.contains(&e.1) {
             continue;
         }
         seen.insert(e.1);
-        inspect_v(g, e.1, indent + 1, seen);
+        inspect_v(g, e.1, indent + 1, seen)?;
     }
+    Ok(())
 }

--- a/tests/inspect_test.rs
+++ b/tests/inspect_test.rs
@@ -5,6 +5,7 @@ mod common;
 
 use crate::common::compiler::compile_one;
 use anyhow::Result;
+use predicates::prelude::{predicate, PredicateBooleanExt};
 use tempfile::TempDir;
 
 #[test]
@@ -32,5 +33,22 @@ fn inspects_one_binary() -> Result<()> {
         .arg(first.as_os_str())
         .assert()
         .success();
+    Ok(())
+}
+
+#[test]
+fn reports_missing_root_without_panicking() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let bin = tmp.path().join("input.reo");
+    compile_one("ADD(ν0);", bin.clone())?;
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .arg("inspect")
+        .arg("--root=999")
+        .arg(bin.as_os_str())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Can't find ν999"))
+        .stderr(predicate::str::contains("panicked").not());
     Ok(())
 }


### PR DESCRIPTION
Closes #242.

`inspect_v()` previously unwrapped graph lookups. As a result, a syntactically valid numeric `--root` that is absent from the graph caused a Rust panic and exit code 101, while the analogous `dot` command propagates the graph error normally.

This changes `inspect_v()` to return `Result<()>` and propagates `kids`, data, UTF-8, and recursive inspection errors with `?`. Its two callers propagate the result as well. Successful inspection output is unchanged.

A regression test builds a graph containing only `ν0`, invokes `reo inspect --root=999`, and asserts a normal failure containing `Can't find ν999` without `panicked` in stderr.

Validation:

- `cargo test --test inspect_test` — passed
- `cargo test --all-targets` — passed
- `cargo fmt --check` — passed
- `git diff --check` — passed
