### PR TITLE
#244: Preserve non-UTF snapshot paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod universe;
 
 use anyhow::Result;
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 /// A single atom to be attached to a vertex.
 ///
@@ -45,7 +46,7 @@ pub struct Universe {
     /// The depth of recursion of the current dataization.
     depth: usize,
     /// Location of snapshots directory.
-    snapshots: Option<String>,
+    snapshots: Option<PathBuf>,
 }
 
 #[cfg(test)]

--- a/src/universe.rs
+++ b/src/universe.rs
@@ -68,7 +68,7 @@ impl Universe {
             g: self.g.clone(),
             atoms: self.atoms.clone(),
             depth: self.depth,
-            snapshots: Some(p.as_os_str().to_str().unwrap().to_string()),
+            snapshots: Some(p.to_path_buf()),
         }
     }
 
@@ -386,36 +386,26 @@ impl Universe {
             return Ok(());
         }
         let p = self.snapshots.clone().unwrap();
-        let home = Path::new(&p);
-        fs::create_dir_all(home)
-            .context(anyhow!("Can't create directory {}", home.to_str().unwrap()))?;
+        let home = p.as_path();
+        fs::create_dir_all(home).context(anyhow!("Can't create directory {}", home.display()))?;
         let total = fs::read_dir(home)
-            .context(anyhow!("Can't list files in {}", home.to_str().unwrap()))?
+            .context(anyhow!("Can't list files in {}", home.display()))?
             .filter(|f| {
                 f.as_ref()
                     .unwrap()
                     .path()
-                    .as_os_str()
-                    .to_str()
-                    .unwrap()
-                    .ends_with(".dot")
+                    .extension()
+                    .is_some_and(|ext| ext == std::ffi::OsStr::new("dot"))
             })
             .count();
-        debug!(
-            "{total} snapshot files already in {}",
-            home.to_str().unwrap()
-        );
+        debug!("{total} snapshot files already in {}", home.display());
         if total == 0 {
-            fs::copy("surge-make/Makefile", home.join("Makefile")).context(anyhow!(
-                "Can't copy Makefile to '{}'",
-                home.to_str().unwrap()
-            ))?;
-            fs::copy("surge-make/doc.tex", home.join("doc.tex")).context(anyhow!(
-                "Can't copy doc.tex to '{}'",
-                home.to_str().unwrap()
-            ))?;
+            fs::copy("surge-make/Makefile", home.join("Makefile"))
+                .context(anyhow!("Can't copy Makefile to '{}'", home.display()))?;
+            fs::copy("surge-make/doc.tex", home.join("doc.tex"))
+                .context(anyhow!("Can't copy doc.tex to '{}'", home.display()))?;
             fs::write(home.join("list.tex"), b"").context(anyhow!("Can't write empty list.tex"))?;
-            debug!("Snapshot dir created: {}", home.to_str().unwrap());
+            debug!("Snapshot dir created: {}", home.display());
         }
         let pos = total + 1;
         let mut before = String::new();
@@ -425,7 +415,7 @@ impl Universe {
             before = fs::read_to_string(b.clone())
                 .context(anyhow!(
                     "Can't read previous {fname} file from '{}'",
-                    home.to_str().unwrap()
+                    home.display()
                 ))?
                 .replace(Self::COLORS, "");
             debug!("Previous snapshot read from: {}", Self::fprint(b));
@@ -462,7 +452,7 @@ impl Universe {
                 let m = Self::fprint(dot_file.clone());
                 fs::remove_file(dot_file.clone()).context(anyhow!(
                     "Can't remove previous .dot file {}",
-                    dot_file.to_str().unwrap()
+                    dot_file.display()
                 ))?;
                 debug!("Similar dot file removed: {m}");
             }
@@ -472,7 +462,7 @@ impl Universe {
                 .open(home.join("list.tex"))
                 .context(anyhow!(
                     "Can't open {}/list.tex for appending",
-                    home.to_str().unwrap()
+                    home.display()
                 ))?;
             writeln!(list, "\\graph{{{pos}}}")?;
         }
@@ -480,10 +470,7 @@ impl Universe {
             .append(true)
             .create(true)
             .open(home.join("log.txt"))
-            .context(anyhow!(
-                "Can't open {}/log.txt for writing",
-                home.to_str().unwrap()
-            ))?;
+            .context(anyhow!("Can't open {}/log.txt for writing", home.display()))?;
         writeln!(
             log,
             "{}{}",
@@ -509,7 +496,7 @@ impl Universe {
     /// Turn file name into a better visible string, for logs.
     fn fprint(f: PathBuf) -> String {
         let size = f.metadata().unwrap().len();
-        format!("{} ({size} bytes)", f.to_str().unwrap())
+        format!("{} ({size} bytes)", f.display())
     }
 }
 
@@ -645,10 +632,8 @@ fn quick_tests() -> Result<()> {
         let p = format!("target/surge/{}", name);
         let home = Path::new(p.as_str());
         if home.exists() {
-            fs::remove_dir_all(home).context(anyhow!(
-                "Can't delete directory '{}'",
-                home.to_str().unwrap()
-            ))?;
+            fs::remove_dir_all(home)
+                .context(anyhow!("Can't delete directory '{}'", home.display()))?;
         }
         let mut uni = Universe::from_graph(g).with_snapshots(home);
         uni.register("inc", inc);

--- a/tests/misc_test.rs
+++ b/tests/misc_test.rs
@@ -26,3 +26,23 @@ fn prints_version() {
         .assert()
         .success();
 }
+
+#[cfg(unix)]
+#[test]
+fn supports_non_utf_snapshot_path() -> anyhow::Result<()> {
+    use reo::Universe;
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new()?;
+    let snapshots = tmp
+        .path()
+        .join(OsString::from_vec(vec![b's', b'n', b'a', b'p', b'-', 0xff]));
+    let mut universe = Universe::empty();
+    universe.add();
+    let mut universe = universe.with_snapshots(&snapshots);
+    assert!(universe.dataize("Φ.missing").is_err());
+    assert!(snapshots.exists());
+    Ok(())
+}


### PR DESCRIPTION
Closes #244.

`Universe::with_snapshots(&Path)` previously converted the snapshots directory to `String` with `to_str().unwrap()`. On Unix, a valid non-UTF-8 path therefore panicked immediately, and the snapshot implementation had additional UTF-8 unwraps on the same path.

This keeps the internal snapshots location as `PathBuf`, uses `Path::display()` for diagnostics, and detects `.dot` snapshot files through `Path::extension()` instead of converting their full path to UTF-8. The public `with_snapshots(&Path)` API is unchanged.

The Unix regression test creates a snapshots directory containing a non-UTF-8 byte, triggers real snapshot generation through a failing dataization, and verifies that the directory is created without a panic.

Validation:

- `cargo test --test misc_test supports_non_utf_snapshot_path -- --nocapture` — passed and wrote snapshot files under the non-UTF path
- `cargo test --all-targets` — passed
- `cargo fmt --check` — passed
- `git diff --check` — passed
