### PR TITLE
#238: Preserve non-UTF CLI paths

### DIFF
--- a/src/bin/reo.rs
+++ b/src/bin/reo.rs
@@ -38,7 +38,7 @@ impl TypedValueParser for PathValueParser {
         if value.is_empty() {
             return Err(clap::Error::raw(EmptyValue, "Can't be empty"));
         }
-        let path = Path::new(value.to_str().unwrap());
+        let path = Path::new(value);
         let abs = if path.exists() {
             fs::canonicalize(path).unwrap()
         } else {

--- a/tests/empty_test.rs
+++ b/tests/empty_test.rs
@@ -20,3 +20,23 @@ fn makes_empty_binary() -> Result<()> {
     assert!(bin.exists());
     Ok(())
 }
+
+#[cfg(unix)]
+#[test]
+fn accepts_non_utf_output_path() -> Result<()> {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let tmp = TempDir::new()?;
+    let bin = tmp.path().join(OsString::from_vec(vec![
+        b'o', b'u', b't', b'-', 0xff, b'.', b'r', b'e', b'o',
+    ]));
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .arg("empty")
+        .arg(bin.as_os_str())
+        .assert()
+        .success();
+    assert!(bin.exists());
+    Ok(())
+}


### PR DESCRIPTION
Closes #238.

`PathValueParser` accepted an `OsStr` but immediately converted it with `to_str().unwrap()`. That made every file-taking subcommand panic on valid Unix paths containing non-UTF-8 bytes before the command itself could operate on the path.

`Path::new()` accepts `&OsStr` directly, so this removes the unnecessary Unicode conversion and keeps the parser working with native filesystem paths.

The Unix regression test invokes `reo empty` with a non-UTF-8 output filename and verifies that the command succeeds and creates the file.

Validation:

- `cargo test --test empty_test` — passed (including the non-UTF path test)
- `cargo test --all-targets` — passed
- `cargo fmt --check` — passed
- `git diff --check` — passed
