### PR TITLE
#212: Validate root IDs in clap

### DIFF
--- a/src/bin/reo.rs
+++ b/src/bin/reo.rs
@@ -146,6 +146,7 @@ pub fn main() -> Result<()> {
                         .short('r')
                         .required(false)
                         .default_value("0")
+                        .value_parser(value_parser!(u32))
                         .help("The ID of the root vertex")
                         .action(ArgAction::Set),
                 )
@@ -200,6 +201,7 @@ pub fn main() -> Result<()> {
                         .short('r')
                         .required(false)
                         .default_value("0")
+                        .value_parser(value_parser!(u32))
                         .help("The ID of the root vertex to print")
                         .action(ArgAction::Set),
                 )
@@ -367,7 +369,7 @@ pub fn main() -> Result<()> {
                 fs::metadata(bin)?.len(),
                 start.elapsed()
             );
-            let root: u32 = subs.get_one::<String>("root").unwrap().parse().unwrap();
+            let root = *subs.get_one::<u32>("root").unwrap();
             let ignore: HashSet<u32> = HashSet::from_iter(
                 subs.get_many("ignore")
                     .unwrap_or(ValuesRef::default())
@@ -401,7 +403,7 @@ pub fn main() -> Result<()> {
             println!("Total vertices: {}", g.len());
             println!("Metas:");
             print_metas(&mut g)?;
-            let root = subs.get_one::<String>("root").unwrap().parse().unwrap();
+            let root = *subs.get_one::<u32>("root").unwrap();
             let mut seen = HashSet::new();
             let ignore: Vec<u32> = subs
                 .get_many("ignore")

--- a/tests/dot_test.rs
+++ b/tests/dot_test.rs
@@ -46,3 +46,15 @@ fn mentions_stdout_fallback_in_help() {
         .success()
         .stdout(predicate::str::contains("prints to stdout when omitted"));
 }
+
+#[test]
+fn rejects_non_numeric_root() {
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .arg("dot")
+        .arg("--root=abc")
+        .arg("missing.reo")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid value"));
+}

--- a/tests/inspect_test.rs
+++ b/tests/inspect_test.rs
@@ -5,6 +5,7 @@ mod common;
 
 use crate::common::compiler::compile_one;
 use anyhow::Result;
+use predicates::prelude::predicate;
 use tempfile::TempDir;
 
 #[test]
@@ -33,4 +34,16 @@ fn inspects_one_binary() -> Result<()> {
         .assert()
         .success();
     Ok(())
+}
+
+#[test]
+fn rejects_non_numeric_root() {
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .arg("inspect")
+        .arg("--root=abc")
+        .arg("missing.reo")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Invalid value"));
 }


### PR DESCRIPTION
Closes #212.

The earlier attempt #226 was self-closed without merge, while the issue remains open and current `master` still parses both `dot --root` and `inspect --root` manually with `parse().unwrap()`.

This types both `--root` arguments as `u32` at the clap layer, matching the existing `--ignore` arguments, and reads the already-parsed `u32` from `ArgMatches`. Invalid roots such as `abc` are now rejected by clap with exit code 2 instead of reaching a Rust panic.

Regression tests cover both subcommands and assert clap's `Invalid value` diagnostic.

Validation:

- `cargo test --test dot_test rejects_non_numeric_root` — passed
- `cargo test --test inspect_test rejects_non_numeric_root` — passed
- `cargo test --all-targets` — passed
- `cargo fmt --check` — passed
- `git diff --check` — passed
