### PR TITLE
#248: Propagate missing atom errors

### DIFF
--- a/src/universe.rs
+++ b/src/universe.rs
@@ -205,14 +205,11 @@ impl Universe {
         } else if let Some(lv) = self.g.kid(v, "λ") {
             let lambda = self.g.data(lv)?.to_utf8()?;
             trace!("#re: calling ν{v}.λ⇓{lambda}(ξ=ν?)...");
-            let to = self
-                .atoms
-                .get(lambda.as_str())
-                .context(anyhow!(
-                    "Can't find function {lambda} among {} others",
-                    self.atoms.len()
-                ))
-                .unwrap()(self, v)?;
+            let atom = self.atoms.get(lambda.as_str()).copied().context(anyhow!(
+                "Can't find function {lambda} among {} others",
+                self.atoms.len()
+            ))?;
+            let to = atom(self, v)?;
             trace!("#re: ν{v}.λ⇓{lambda}(ξ=ν?) returned ν{to}");
             self.fnd(to, a, psi)?
         } else if let Some(to) = self.g.kid(v, "φ") {

--- a/tests/dataize_test.rs
+++ b/tests/dataize_test.rs
@@ -5,6 +5,7 @@ mod common;
 
 use crate::common::compiler::compile_one;
 use anyhow::Result;
+use predicates::prelude::{predicate, PredicateBooleanExt};
 use tempfile::TempDir;
 
 #[test]
@@ -52,5 +53,32 @@ fn dumps_after_mistake() -> Result<()> {
         .assert()
         .failure();
     assert!(dump.exists());
+    Ok(())
+}
+
+#[test]
+fn reports_unregistered_atom_without_panicking() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let bin = tmp.path().join("missing-atom.reo");
+    compile_one(
+        "
+        ADD(ν0);
+        ADD($ν1);
+        BIND(ν0, $ν1, foo);
+        ADD($ν2);
+        BIND($ν1, $ν2, λ);
+        PUT($ν2, 6D-69-73-73-69-6E-67);
+        ",
+        bin.clone(),
+    )?;
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .arg("dataize")
+        .arg(bin.as_os_str())
+        .arg("foo")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Can't find function missing"))
+        .stderr(predicate::str::contains("panicked").not());
     Ok(())
 }


### PR DESCRIPTION
Closes #248.

When a graph's `λ` names an atom that is not registered, `Universe::pf()` already constructs a useful `anyhow` context (`Can't find function ...`) but then immediately unwraps it, turning the recoverable lookup failure into a Rust panic.

This copies the function pointer out of the atom map, propagates the contextual lookup error with `?`, and then calls the atom normally. Successful atom dispatch behavior is unchanged.

The regression test compiles a real `.reo` graph whose `λ` contains `missing`, runs the CLI `dataize` command, and verifies a normal failure containing `Can't find function missing` without `panicked` in stderr.

Validation:

- `cargo test --test dataize_test reports_unregistered_atom_without_panicking` — passed
- `cargo test --all-targets` — passed
- `cargo fmt --check` — passed
- `git diff --check` — passed
