### PR TITLE
#250: Write complete DOT output

### DIFF
--- a/src/bin/reo.rs
+++ b/src/bin/reo.rs
@@ -384,7 +384,7 @@ pub fn main() -> Result<()> {
                 }
                 None => Box::new(io::stdout()) as Box<dyn Write>,
             };
-            let bytes = out.write(content.as_bytes())?;
+            let bytes = write_dot(&mut *out, &content)?;
             info!("DOT graph saved, {bytes} bytes in {:?}", start.elapsed());
         }
         Some(("inspect", subs)) => {
@@ -454,6 +454,11 @@ pub fn main() -> Result<()> {
     Ok(())
 }
 
+fn write_dot(out: &mut dyn Write, content: &str) -> Result<usize> {
+    out.write_all(content.as_bytes())?;
+    Ok(content.len())
+}
+
 fn print_metas(g: &mut Sodg) -> Result<()> {
     match g.kids(0) {
         Ok(vec) => {
@@ -488,5 +493,41 @@ fn inspect_v(g: &mut Sodg, v: u32, indent: usize, seen: &mut HashSet<u32>) {
         }
         seen.insert(e.1);
         inspect_v(g, e.1, indent + 1, seen);
+    }
+}
+
+#[cfg(test)]
+mod output_tests {
+    use super::write_dot;
+    use std::io::{Result as IoResult, Write};
+
+    struct ShortWriter {
+        bytes: Vec<u8>,
+        limit: usize,
+    }
+
+    impl Write for ShortWriter {
+        fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+            let size = self.limit.min(buf.len());
+            self.bytes.extend_from_slice(&buf[..size]);
+            Ok(size)
+        }
+
+        fn flush(&mut self) -> IoResult<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn writes_complete_dot_after_short_writes() -> anyhow::Result<()> {
+        let content = "digraph { v0 -> v1; }";
+        let mut out = ShortWriter {
+            bytes: Vec::new(),
+            limit: 3,
+        };
+        let written = write_dot(&mut out, content)?;
+        assert_eq!(content.len(), written);
+        assert_eq!(content.as_bytes(), out.bytes.as_slice());
+        Ok(())
     }
 }


### PR DESCRIPTION
Closes #250.

`reo dot` used one `Write::write()` call and treated any `Ok(n)` as success. The `Write` contract permits short writes, so a pipe/stdout or another writer could accept only a prefix and leave a truncated DOT while the command still exited successfully.

This routes DOT output through a small helper using `write_all()` and reports the full content length only after all bytes are accepted.

A regression test uses a writer that accepts at most three bytes per `write()` call. It verifies that the helper retries until the complete DOT is present; a one-shot `write()` implementation would fail this test deterministically.

Validation in Termux:
- `cargo fmt --check`
- focused short-write regression test
- `cargo test --all-targets`

All passed. The build notes that Maven-generated EO fixtures were not regenerated locally, as before; the Rust test suite itself passed.
