### PR TITLE
#252: Stop leaking application depth

### DIFF
--- a/src/universe.rs
+++ b/src/universe.rs
@@ -264,7 +264,6 @@ impl Universe {
     /// Apply `v1` to `v2` and return a new vertex.
     fn apply(&mut self, v1: u32, v2: u32) -> Result<u32> {
         enter!(self, "#apply(ν{v1}, ν{v2}): entering...");
-        self.depth += 1;
         let nv = self.g.next_id();
         self.g.add(nv)?;
         self.pull(nv, v1)?;
@@ -603,6 +602,29 @@ fn fnd_absent_vertex() -> Result<()> {
     let mut uni = Universe::from_graph(g);
     uni.add();
     assert!(uni.dataize("ν42.foo").is_err());
+    Ok(())
+}
+
+#[test]
+fn dataizes_repeated_application_without_leaking_depth() -> Result<()> {
+    let mut script = Script::from_str(
+        "
+        ADD(ν0);
+        ADD($ν1);
+        ADD($ν2);
+        BIND($ν1, $ν2, Δ);
+        PUT($ν2, 00-00-00-00-00-00-00-2A);
+        ADD($ν3);
+        BIND($ν3, $ν1, π);
+        BIND(ν0, $ν3, foo);
+        ",
+    );
+    let mut graph = Sodg::empty();
+    script.deploy_to(&mut graph)?;
+    let mut universe = Universe::from_graph(graph);
+    for _ in 0..30 {
+        assert_eq!(42, universe.dataize("Φ.foo")?.to_i64()?);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Closes #252.

`enter!()` already calls `enter_it()`, which increments the recursion-depth counter. `Universe::apply()` incremented `self.depth` a second time and had only one matching `exit!()`, leaking one level after every successful application.

The leak is externally visible: on master a non-recursive copy object returning 42 can be dataized repeatedly, but depth rises after every call and the 19th call fails with `The recursion is too deep (21 levels)`.

This removes the duplicate increment. The regression test builds one simple `π` application and dataizes it 30 times in the same Universe, asserting 42 each time.

Validation in Termux:
- focused regression test
- `cargo fmt --check`
- `cargo test --all-targets`

All passed.
