### PR TITLE
#254: Restore lookup depth after failure

### DIFF
--- a/src/universe.rs
+++ b/src/universe.rs
@@ -141,11 +141,13 @@ impl Universe {
         if self.g.is_empty() {
             return Err(anyhow!("The Universe is empty, can't dataize {loc}"));
         }
-        let v = self
+        let depth = self.depth;
+        let found = self
             .g
             .find(0, loc, self)
-            .context(format!("Failed to find {loc}"))?;
-        Ok(v)
+            .context(format!("Failed to find {loc}"));
+        self.depth = depth;
+        found
     }
 
     /// Get a slice of the graph by the locator.
@@ -603,6 +605,33 @@ fn fnd_absent_vertex() -> Result<()> {
     let mut uni = Universe::from_graph(g);
     uni.add();
     assert!(uni.dataize("ν42.foo").is_err());
+    Ok(())
+}
+
+#[test]
+fn recovers_depth_after_failed_dataization() -> Result<()> {
+    let mut script = Script::from_str(
+        "
+        ADD(ν0);
+        ADD($ν1);
+        BIND(ν0, $ν1, bad);
+        ADD($ν2);
+        BIND($ν1, $ν2, φ);
+        BIND($ν2, $ν1, φ);
+        ADD($ν3);
+        ADD($ν4);
+        BIND($ν3, $ν4, Δ);
+        PUT($ν4, 00-00-00-00-00-00-00-2A);
+        ADD($ν5);
+        BIND($ν5, $ν3, π);
+        BIND(ν0, $ν5, good);
+        ",
+    );
+    let mut graph = Sodg::empty();
+    script.deploy_to(&mut graph)?;
+    let mut universe = Universe::from_graph(graph);
+    assert!(universe.dataize("Φ.bad").is_err());
+    assert_eq!(42, universe.dataize("Φ.good")?.to_i64()?);
     Ok(())
 }
 


### PR DESCRIPTION
Closes #254.

Recursive lookup helpers increment `Universe.depth` through `enter!()`, but errors propagated by `?` bypass their matching `exit!()` calls. A failed recursive dataization therefore leaves the shared Universe at the failure depth and can make the next unrelated lookup fail immediately.

`find()` now preserves the depth that was active at its entry and restores it after `g.find(...)` returns, before propagating either success or failure. This is also safe for nested `dataize()` calls from atoms: they restore the caller's existing depth rather than forcing it to zero.

The regression builds a Universe containing a cyclic `bad` object and a valid non-recursive application `good=42`. It first confirms `bad` fails, then confirms `good` still dataizes to 42 in the same Universe. On master the second lookup fails with `The recursion is too deep (22 levels)`.

Validation in Termux:
- focused regression test
- `cargo fmt --check`
- `cargo test --all-targets`

All passed.
