### PR TITLE
#256: Reject out-of-range positional attributes

### DIFF
--- a/src/universe.rs
+++ b/src/universe.rs
@@ -345,7 +345,7 @@ impl Universe {
                 .into_iter()
                 .filter(|(aa, _)| aa.is_ascii())
                 .nth(i)
-                .unwrap();
+                .ok_or(anyhow!("Can't find positional attribute α{i} in ν{v}"))?;
             trace!("#tie(ν{v}, {a}): the {i}th attribute is {}", a1.0);
             return self.tie(v, a1.0);
         }
@@ -603,6 +603,18 @@ fn fnd_absent_vertex() -> Result<()> {
     let mut uni = Universe::from_graph(g);
     uni.add();
     assert!(uni.dataize("ν42.foo").is_err());
+    Ok(())
+}
+
+#[test]
+fn rejects_out_of_range_positional_attribute_without_panicking() -> Result<()> {
+    let source = fs::read_to_string("quick-tests/14-times-of-alpha.sodg")?.replace("α0", "α99");
+    let mut script = Script::from_str(&source);
+    let mut graph = Sodg::empty();
+    script.deploy_to(&mut graph)?;
+    let mut universe = Universe::from_graph(graph);
+    universe.register("times", times);
+    assert!(universe.dataize("Φ.foo").is_err());
     Ok(())
 }
 


### PR DESCRIPTION
Closes #256.

`Universe::tie()` used `unwrap()` after selecting the `N`th available attribute for an `αN` binding. If an application supplies an out-of-range positional argument, `.nth(i)` returns `None` and reo panics instead of returning a normal runtime error.

This replaces the unwrap with an `anyhow` error that names the missing positional attribute and vertex.

The regression reuses the existing working `quick-tests/14-times-of-alpha.sodg` fixture, changes only `α0` to `α99`, registers the same `times` atom, and asserts that dataization returns `Err`. On master this exact test panics at the unwrap.

Validation in Termux:
- focused regression test
- `cargo fmt --check`
- `cargo test --all-targets`

All passed.
