### PR TITLE
#239: Replace obsolete tarpaulin action

### DIFF
--- a/.github/workflows/tarpaulin.yml
+++ b/.github/workflows/tarpaulin.yml
@@ -16,14 +16,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.15.0'
-          args: '-- --test-threads 1'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-tarpaulin
+      - run: cargo tarpaulin --out xml -- --test-threads 1
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Closes #239.

The coverage workflow no longer downloads tarpaulin 0.15.0 through the unmaintained `actions-rs/tarpaulin` action. That binary is linked against OpenSSL 1.1 and cannot start on `ubuntu-24.04`, so recent coverage runs have failed before executing tests.

This PR:
- replaces `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable`;
- installs a current `cargo-tarpaulin` via `taiki-e/install-action@cargo-tarpaulin`;
- runs `cargo tarpaulin --out xml -- --test-threads 1` directly;
- leaves the existing Codecov upload/fail policy unchanged.

The workflow parses as YAML and `git diff --check` is clean.
