### PR TITLE
#259: Render binary lambda payloads during inspection

### DIFF
--- a/src/bin/reo.rs
+++ b/src/bin/reo.rs
@@ -480,7 +480,11 @@ fn inspect_v(g: &mut Sodg, v: u32, indent: usize, seen: &mut HashSet<u32>) {
             print!(" {}", g.data(e.1).unwrap().to_string().blue());
         }
         if e.0 == "λ" {
-            print!(" {}", g.data(e.1).unwrap().to_utf8().unwrap().yellow());
+            let data = g.data(e.1).unwrap();
+            print!(
+                " {}",
+                data.to_utf8().unwrap_or_else(|_| data.to_string()).yellow()
+            );
         }
         println!();
         if seen.contains(&e.1) {

--- a/tests/inspect_test.rs
+++ b/tests/inspect_test.rs
@@ -5,6 +5,7 @@ mod common;
 
 use crate::common::compiler::compile_one;
 use anyhow::Result;
+use predicates::prelude::predicate;
 use tempfile::TempDir;
 
 #[test]
@@ -32,5 +33,28 @@ fn inspects_one_binary() -> Result<()> {
         .arg(first.as_os_str())
         .assert()
         .success();
+    Ok(())
+}
+
+#[test]
+fn inspects_non_utf8_lambda_payload() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let binary = tmp.path().join("nonutf8.reo");
+    compile_one(
+        "
+        ADD(ν0);
+        ADD($ν1);
+        BIND(ν0, $ν1, λ);
+        PUT($ν1, ff);
+        ",
+        binary.clone(),
+    )?;
+    assert_cmd::Command::cargo_bin("reo")
+        .unwrap()
+        .arg("inspect")
+        .arg(binary.as_os_str())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("λ -> ν1 FF"));
     Ok(())
 }


### PR DESCRIPTION
Closes #259.

`reo inspect` no longer unwraps UTF-8 conversion for `λ` payloads. It keeps the existing text rendering when the bytes are valid UTF-8 and falls back to the `Hex` representation when they are binary, so the diagnostic command can still inspect the graph instead of panicking with exit 101.

A regression test compiles a minimal graph whose lambda payload is `ff`, runs the real `reo inspect` binary, requires a successful exit, and verifies `λ -> ν1 FF` is printed.

Local verification on this branch:
- `cargo test --test inspect_test` — PASS;
- `cargo fmt -- --check` — PASS;
- `git diff --check` — PASS.
